### PR TITLE
DNS向けのリトライ機構を追加

### DIFF
--- a/paper/main.py
+++ b/paper/main.py
@@ -1,5 +1,7 @@
 import os
+import socket
 import sys
+import time
 import urllib3
 from datetime import datetime
 from typing import List
@@ -36,6 +38,15 @@ MINIO_ROOT_USER = os.getenv("MINIO_ROOT_USER", "minio")
 MINIO_ROOT_PASSWORD = os.getenv("MINIO_ROOT_PASSWORD", "minio123")
 MINIO_HOST = os.getenv("MINIO_HOST", "minio:9000")
 MINIO_BUCKET_NAME = os.getenv("MINIO_BUCKEt_NAME", "paper")
+
+for _ in range(120):
+    try:
+        res = socket.getaddrinfo(MINIO_HOST, None)
+        break
+    except Exception as e:
+        print("Retry resolve host:", e)
+        time.sleep(1)
+        continue
 
 try:
     minio_client = Minio(


### PR DESCRIPTION
docker-composeでFastAPIが起動しない問題への対策を追加．

```
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='minio', port=9000): Max retries exceeded with url: /paper?location= (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffffad6b3100>: Failed to establish a new connection: [Errno -2] Name does not resolve'))

```

名前解決できるまでsleepを挟んでリトライを行う．

**実際のログ**

```
paper-compose_1   | app_1            | INFO:     Application startup complete.
paper-compose_1   | app_1            | MongoDB connected.
paper-compose_1   | app_1            | Retry resolve host: [Errno -2] Name does not resolve
paper-compose_1   | app_1            | Retry resolve host: [Errno -2] Name does not resolve
...
paper-compose_1   | app_1            | Retry resolve host: [Errno -2] Name does not resolve
paper-compose_1   | app_1            | Bucket 'paper' already exists
paper-compose_1   | app_1            | INFO:     172.20.0.1:60280 - "GET / HTTP/1.1" 200 OK
paper-compose_1   | app_1            | INFO:     172.20.0.1:60280 - "GET / HTTP/1.1" 200 OK
```