### PR TITLE
front-adminへ論文追加（PDFアップロード）を実装

### DIFF
--- a/front-admin/main.py
+++ b/front-admin/main.py
@@ -138,6 +138,7 @@ async def add_paper_handler(request: Request,
             """ Add paper pdf file """
             url_file = (f"http://{SVC_PAPER_HOST}:{SVC_PAPER_PORT}"
                         f"/paper/{paper_uuid}/upload")
+            # FIXME: ここを修正する
             payload = aiohttp.FormData()
             payload.add_field('file', b'pdffile', filename=f"{paper_uuid}.pdf",
                               content_type='application/pdf')

--- a/front-admin/main.py
+++ b/front-admin/main.py
@@ -1,8 +1,8 @@
 import asyncio
 import os
-from typing import Optional
+from typing import List, Optional
 
-from fastapi import FastAPI, Request, HTTPException, Form
+from fastapi import FastAPI, Request, HTTPException, Form, UploadFile, File
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 import aiohttp
@@ -88,8 +88,23 @@ async def add_paper_exec_handler(request: Request):
 
 
 @app.post("/paper/add")
-def add_paper_handler(request: Request):
-    return templates.TemplateResponse("paper-add.html", {"request": request})
+def add_paper_handler(request: Request,
+                      title: str = Form(...),
+                      author: List[str] = Form(...),
+                      keywords: Optional[str] = Form(None),
+                      label: Optional[str] = Form(None),
+                      publish: bool = Form(True),
+                      pdffile: bytes = File(...)
+                      ):
+    return {
+        "title": title,
+        "author": author,
+        "keywords": keywords,
+        "label": label,
+        "publish": publish,
+        "pdffile": len(pdffile)
+    }
+    # return templates.TemplateResponse("paper-add.html", {"request": request})
 
 
 @app.get("/author")

--- a/front-admin/templates/author-add.html
+++ b/front-admin/templates/author-add.html
@@ -9,28 +9,28 @@
 <form method="post" action="/author/add">
     <table>
         <tr>
-            <th><label for="fname-ja">姓(日本語)</label></th>
-            <td><input type="text" name="first_name_ja" id="fname-ja"></td>
+            <th><label for="lname-ja">姓(日本語)</label></th>
+            <td><input type="text" name="last_name_ja" id="lname-ja"></td>
         </tr>
         <tr>
             <th><label for="mname-ja">ミドルネーム(日本語)</label></th>
             <td><input type="text" name="middle_name_ja" id="mname-ja"></td>
         </tr>
         <tr>
-            <th><label for="lname-ja">名(日本語)</label></th>
-            <td><input type="text" name="last_name_ja" id="lname-ja"></td>
+            <th><label for="fname-ja">名(日本語)</label></th>
+            <td><input type="text" name="first_name_ja" id="fname-ja"></td>
         </tr>
         <tr>
-            <th><label for="fname-en">姓(英語)</label></th>
-            <td><input type="text" name="first_name_en" id="fname-en"></td>
+            <th><label for="lname-en">姓(英語)</label></th>
+            <td><input type="text" name="last_name_en" id="lname-en"></td>
         </tr>
         <tr>
             <th><label for="mname-en">ミドルネーム(英語)</label></th>
             <td><input type="text" name="middle_name_en" id="mname-en"></td>
         </tr>
         <tr>
-            <th><label for="lname-en">名(英語)</label></th>
-            <td><input type="text" name="last_name_en" id="lname-en"></td>
+            <th><label for="fname-en">名(英語)</label></th>
+            <td><input type="text" name="first_name_en" id="fname-en"></td>
         </tr>
         <tr>
             <th><label for="year">参加年(半角英数)</label></th>

--- a/front-admin/templates/paper-add.html
+++ b/front-admin/templates/paper-add.html
@@ -43,7 +43,7 @@
         </tr>
         <tr>
             <th></th>
-            <td><button type="button" style="width: 100%;">送信</button></td>
+            <td><button type="submit" style="width: 100%;">送信</button></td>
         </tr>
     </table>
 </form>

--- a/front-admin/templates/paper-add.html
+++ b/front-admin/templates/paper-add.html
@@ -6,7 +6,7 @@
 <body>
 <h1>論文の追加</h1>
 
-<form method="post" action="/paper/add">
+<form method="post" action="/paper/add" enctype="multipart/form-data">
     <table>
         <tr>
             <th><label for="title">タイトル</label></th>

--- a/front-admin/templates/paper-add.html
+++ b/front-admin/templates/paper-add.html
@@ -12,16 +12,19 @@
             <th><label for="title">タイトル</label></th>
             <td><input type="text" name="title" id="title"></td>
         </tr>
+        {% for i in range(1, 4) %}
         <tr>
-            <th><label for="author">著者</label></th>
+            <th><label for="author{{ i }}">著者{{ i }}</label></th>
             <td>
-                <select name="author" id="author" multiple>
+                <select name="author{{ i }}" id="author{{ i }}">
+                    <option value="" selected>---</option>
                     {% for author in authors %}
                     <option value="{{ author.uuid }}">{{ author.name }}</option>
                     {% endfor %}
                 </select>
             </td>
         </tr>
+        {% endfor %}
         <tr>
             <th><label for="keywords">キーワード<br>(カンマ区切り)</label></th>
             <td><input type="text" name="keywords" id="keywords"></td>


### PR DESCRIPTION
# 主な実装内容

- `front-admin`における入力画面 `GET /paper/add` を追加
- `front-admin` におけるバックエンド処理を追加
  - フォーム入力項目の受け取り
  - `paper`における`POST /paper`へ論文追加リクエストの送信
  - `paper`における`POST /paper/{paper_uuid}/uload`への論文ファイルの送信

# デモ動画

https://user-images.githubusercontent.com/2428176/133104905-547ce0a7-bcf1-4830-b31f-a35e15765a80.mov