### PR TITLE
front-adminのアップロードに失敗する現象への対処

### DIFF
--- a/front-admin/main.py
+++ b/front-admin/main.py
@@ -161,6 +161,12 @@ async def add_paper_exec_handler(request: Request,
                 res_file_detail = res_file.json()
                 print("Response on file:", res_file_detail)
 
+        except Exception as e:
+            print("HTTP Request failed:", e)
+            raise HTTPException(status_code=503, detail="Internal Error")
+
+    async with aiohttp.ClientSession() as session:
+        try:
             """ Add fulltext """
             url_text = (f"http://{SVC_FULLTEXT_HOST}:{SVC_FULLTEXT_PORT}"
                         f"/fulltext/{paper_uuid}")
@@ -184,7 +190,6 @@ async def add_paper_exec_handler(request: Request,
                                         detail="Internal Error")
                 res_thumb = res_thumb.json()
                 print("Response on thumbnail:", res_thumb)
-
         except Exception as e:
             print("HTTP Request failed:", e)
             raise HTTPException(status_code=503, detail="Internal Error")

--- a/front-admin/main.py
+++ b/front-admin/main.py
@@ -179,17 +179,17 @@ async def add_paper_exec_handler(request: Request,
                 res_text_detail = res_text.json()
                 print("Response on text:", res_text_detail)
 
-            """ Add thumbnail """
-            url_thumb = (f"http://{SVC_THUMBNAIL_HOST}:{SVC_THUMBNAIL_PORT}"
-                         f"/thumbnail/{paper_uuid}")
-            print("Request url for thumbnail:", url_thumb)
-            async with session.post(url_thumb) as res_thumb:
-                if res_thumb.status != 200:
-                    print("Invalid status on text:", res_thumb.status)
-                    raise HTTPException(status_code=503,
-                                        detail="Internal Error")
-                res_thumb = res_thumb.json()
-                print("Response on thumbnail:", res_thumb)
+            # """ Add thumbnail """
+            # url_thumb = (f"http://{SVC_THUMBNAIL_HOST}:{SVC_THUMBNAIL_PORT}"
+            #              f"/thumbnail/{paper_uuid}")
+            # print("Request url for thumbnail:", url_thumb)
+            # async with session.post(url_thumb) as res_thumb:
+            #     if res_thumb.status != 200:
+            #         print("Invalid status on text:", res_thumb.status)
+            #         raise HTTPException(status_code=503,
+            #                             detail="Internal Error")
+            #     res_thumb = res_thumb.json()
+            #     print("Response on thumbnail:", res_thumb)
         except Exception as e:
             print("HTTP Request failed:", e)
             raise HTTPException(status_code=503, detail="Internal Error")

--- a/fulltext/main.py
+++ b/fulltext/main.py
@@ -18,6 +18,14 @@ ELASTICSEARCH_HOST = os.getenv(
     "ELASTICSEARCH_HOST", "fulltext-elastic:9200")
 ELASTICSEARCH_INDEX = os.getenv("ELASTICSEARCH_INDEX", "fulltext")
 
+for _ in range(120):
+    try:
+        res = socket.getaddrinfo(ELASTICSEARCH_HOST, None)
+        break
+    except Exception as e:
+        print("Retry resolve host:", e)
+        time.sleep(1)
+
 es = Elasticsearch(f"http://{ELASTICSEARCH_HOST}")
 es.indices.create(index=ELASTICSEARCH_INDEX, ignore=400)
 


### PR DESCRIPTION
- thumbnailをfront-adminの論文追加時に呼び出す処理をコメントアウト
    - タイムアウトが発生するため
- thumbnailとfulltextをasyncから分離