### PR TITLE
update container base image 'python:3.12-slim-bookworm'

### DIFF
--- a/fulltext/Dockerfile
+++ b/fulltext/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-buster
+FROM python:3.12-slim-bookworm
 WORKDIR /work
 COPY main.py requirements.txt /work/
 RUN apt-get update && \

--- a/thumbnail/Dockerfile
+++ b/thumbnail/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-buster
+FROM python:3.12-slim-bookworm
 WORKDIR /work
 COPY main.py requirements.txt /work/
 RUN pip install -U pip && \


### PR DESCRIPTION
## What

Fix base image as python:3.12-slim-bookworm

## Why

Python 3.12 does not support slim-buster.
