### PR TITLE
fixed pymongo connector

### DIFF
--- a/author/main.py
+++ b/author/main.py
@@ -15,9 +15,9 @@ MONGO_USERNAME = os.getenv("MONGO_USERNAME", "root")
 MONGO_PASSWORD = os.getenv("MONGO_PASSWORD", "example")
 MONGO_DBNAME = os.getenv("MONGO_DBNAME", "author")
 MONGO_HOST = os.getenv("MONGO_HOST", "mongo")
-MONGO_CONNECTION_STRING = f"mongodb://{MONGO_USERNAME}:{MONGO_PASSWORD}@{MONGO_HOST}/"
+MONGO_CONNECTION_STRING = f"mongodb://{MONGO_USERNAME}:{MONGO_PASSWORD}@{MONGO_HOST}/?uuidRepresentation=pythonLegacy"
 
-client = MongoClient(MONGO_CONNECTION_STRING)
+client = MongoClient(MONGO_CONNECTION_STRING, )
 db = client[MONGO_DBNAME]
 
 app = FastAPI()


### PR DESCRIPTION
## What

- Fixed UUID handling for PyMongo

## Why

- Default UUID handling changed from PyMongo 4.0

> Starting in PyMongo 4.0, UNSPECIFIED is the default UUID representation used by PyMongo.
> https://pymongo.readthedocs.io/en/stable/examples/uuid.html

