### PR TITLE
Add topologySpreadConstraints on author

### DIFF
--- a/deploy/author/author-app.yml
+++ b/deploy/author/author-app.yml
@@ -18,6 +18,13 @@ spec:
       labels:
         app: author
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: author  # REPLACE_TAG for author-app
       containers:
         - name: author-app-container
           image: ghcr.io/cdsl-research/author:master-844b336


### PR DESCRIPTION
This pull request introduces a configuration update to improve pod scheduling in Kubernetes by adding topology spread constraints to the `author-app` deployment.

### Kubernetes configuration update:

* [`deploy/author/author-app.yml`](diffhunk://#diff-4decfbf1211f0670fa2158b58fd37e923953689555c8e2fd48b050a09349ce3fR21-R27): Added `topologySpreadConstraints` to ensure better distribution of pods across nodes based on the `kubernetes.io/hostname` topology key, with the `ScheduleAnyway` policy applied when constraints are unsatisfiable. This helps enhance reliability and fault tolerance.