### PR TITLE
Update image tags to master-621614c (except front-admin)

### DIFF
--- a/deploy/author/author-app.yml
+++ b/deploy/author/author-app.yml
@@ -27,7 +27,7 @@ spec:
               app: author  # REPLACE_TAG for author-app
       containers:
         - name: author-app-container
-          image: ghcr.io/cdsl-research/author:master-8a1a0af
+          image: ghcr.io/cdsl-research/author:master-621614c
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/deploy/front/front-app.yml
+++ b/deploy/front/front-app.yml
@@ -27,7 +27,7 @@ spec:
               app: front
       containers:
         - name: front-app-container
-          image: ghcr.io/cdsl-research/front:master-8a1a0af
+          image: ghcr.io/cdsl-research/front:master-621614c
           imagePullPolicy: IfNotPresent
           ports:
             - name: health-port

--- a/deploy/fulltext/fulltext-app.yml
+++ b/deploy/fulltext/fulltext-app.yml
@@ -27,7 +27,7 @@ spec:
               app: fulltext
       containers:
         - name: fulltext-app-container
-          image: ghcr.io/cdsl-research/fulltext:master-8a1a0af
+          image: ghcr.io/cdsl-research/fulltext:master-621614c
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/deploy/paper/paper-app.yml
+++ b/deploy/paper/paper-app.yml
@@ -27,7 +27,7 @@ spec:
               app: paper
       containers:
         - name: paper-app-container
-          image: ghcr.io/cdsl-research/paper:master-8a1a0af
+          image: ghcr.io/cdsl-research/paper:master-621614c
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/deploy/stats/stats-app.yml
+++ b/deploy/stats/stats-app.yml
@@ -27,7 +27,7 @@ spec:
               app: stats
       containers:
         - name: stats-app-container
-          image: ghcr.io/cdsl-research/stats:master-8a1a0af
+          image: ghcr.io/cdsl-research/stats:master-621614c
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/deploy/thumbnail/thumbnail-app.yml
+++ b/deploy/thumbnail/thumbnail-app.yml
@@ -27,7 +27,7 @@ spec:
               app: thumbnail
       containers:
         - name: thumbnail-app-container
-          image: ghcr.io/cdsl-research/thumbnail:master-8a1a0af
+          image: ghcr.io/cdsl-research/thumbnail:master-621614c
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
最新ビルド済みイメージ `master-621614c` に更新する。

`621614c` は master 上でビルドが存在する**最新コミット**(2026-05-27 21:00)で、thumbnail の MinIO ホスト名解決修正(#453)を含む。

## 対象(6サービス)
author / front / fulltext / paper / stats / thumbnail → `master-621614c`

## 据え置き
- **front-admin**: `621614c` のイメージが ghcr に存在しない(CI ビルド欠落)ため `master-8a1a0af` のまま(指示により対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)