### PR TITLE
Fix front-admin dependency conflict and upgrade deprecated CI actions

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -29,13 +29,13 @@ jobs:
           ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -48,7 +48,7 @@ jobs:
           echo "DOCKER_TAG=${CUR_BRANCH}-${COMMITID}" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./${{ matrix.target }}
           push: true
@@ -60,7 +60,7 @@ jobs:
     if: ${{ github.event.pusher.name != 'github-actions' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Update k8s config
         run: |
           COMMITID=$(git rev-parse --short ${{ github.sha }} | cut -c1-7)

--- a/.github/workflows/kubelint.yml
+++ b/.github/workflows/kubelint.yml
@@ -7,7 +7,7 @@ jobs:
   kubelint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Scan repo with kube-linter
         uses: stackrox/kube-linter-action@v1.0.2

--- a/front-admin/requirements.txt
+++ b/front-admin/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.5.0
 aiohttp==3.13.3
 aiosignal==1.3.2
 annotated-types==0.7.0


### PR DESCRIPTION
Bump aiohappyeyeballs to 2.5.0 to satisfy aiohttp 3.13.3's >=2.5.0 requirement, resolving the image-build failure. Also upgrade Node.js 20 deprecated GitHub Actions (checkout v4, docker actions v3/v6).