### PR TITLE
Bump aiosignal to 1.4.0 for aiohttp 3.13.3 compatibility

### DIFF
--- a/front-admin/requirements.txt
+++ b/front-admin/requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.5.0
 aiohttp==3.13.3
-aiosignal==1.3.2
+aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.8.0
 asgiref==3.8.1


### PR DESCRIPTION
aiohttp 3.13.3 requires aiosignal>=1.4.0, but front-admin pinned 1.3.2, causing a second ResolutionImpossible after the aiohappyeyeballs fix. Verified locally that `docker build ./front-admin` now succeeds.