### PR TITLE
style: フッターのUIをサイト全体と統一

### DIFF
--- a/front/templates/_footer.html
+++ b/front/templates/_footer.html
@@ -1,6 +1,6 @@
-<footer>
-    <p class="text-center mt-4">
-        <a class="text-blue-500" href="https://ja.tak-cslab.org/">クラウド・分散システム研究室</a>で作成されたテクニカルレポートを公開しています．
+<footer class="border-t border-gray-200 mt-8 py-6">
+    <p class="text-center text-xs text-gray-400">
+        <a class="text-blue-600 hover:underline" href="https://ja.tak-cslab.org/">クラウド・分散システム研究室</a>で作成されたテクニカルレポートを公開しています．
         <br>
         &copy; 2021 Cloud and Distributed Systems Laboratory.
     </p>


### PR DESCRIPTION
- border-t border-gray-200 で上部に区切り線を追加
- mt-8 py-6 で余白をコンテンツと統一
- text-xs text-gray-400 で補助テキストのスタイルに合わせる
- リンクを text-blue-600 hover:underline に統一（旧: text-blue-500）

https://claude.ai/code/session_01Wv8pxv5VMx2Lp7yaespQdn